### PR TITLE
1) вывод блока 'Официальные новости' на страницу 'поставщику'

### DIFF
--- a/wp-content/themes/Prozzoro/css/search.css
+++ b/wp-content/themes/Prozzoro/css/search.css
@@ -56,6 +56,15 @@ ul.language-chooser{list-style: none;padding: 0;margin: 0;display: inline-block;
 .sections.expanded > li > a { margin-bottom:0;}
 .sections > li.active, .sections.expanded > li.active,  .sections.expanded > li.active > a {width:100%;}
 
+.startpopup{position: fixed;display: none;z-index: 25;top: 0;left: 0;width: 100%;height: 100%;background-color: rgba(255,255,255,0.61);}
+.startpopup-wrapper {position: absolute;z-index: 25;width: 40.25%;min-width: 300px;height: auto;min-height: 350px;top: 50%;left: 50%;-webkit-transform: translateY(-50%) translateX(-50%);-moz-transform: translateY(-50%) translateX(-50%);-o-transform: translateY(-50%) translateX(-50%);-ms-transform: translateY(-50%) translateX(-50%);transform: translateY(-50%) translateX(-50%);background-color: #fff;border:2px solid #2ab2ea;padding: 50px;text-align: center;-webkit-box-shadow: 7px 7px 0px 0px rgba(0, 0, 0, 0.11);-moz-box-shadow:    7px 7px 0px 0px rgba(0, 0, 0, 0.11);box-shadow:         7px 7px 0px 0px rgba(0, 0, 0, 0.11);}
+.startpopup-wrapper h1{text-align: center;}
+.startpopup-wrapper h1#title{margin:0 0 50px;}
+.startpopup-wrapper #btn a{padding: 25px;-webkit-box-shadow: 7px 7px 0px 0px rgba(0, 0, 0, 0.11);-moz-box-shadow:    7px 7px 0px 0px rgba(0, 0, 0, 0.11);box-shadow:         7px 7px 0px 0px rgba(0, 0, 0, 0.11);}
+.startpopup-wrapper a{width: 90%;display: block;margin: 25px auto;}
+.startpopup-wrapper .close-startpopup {display: block;position: absolute;top:-33px;right: 0;float: right;width: 25px;height: 25px;background-color: #fff;border: 2px solid #2ab2ea;border-radius: 50%;margin: 0;font-size: 20px;line-height: 20px;}
+.startpopup-wrapper a.close-startpopup:hover,.startpopup-wrapper a.close-startpopup:focus{text-decoration: none;}
+
 @media (max-width: 1190px) {
 .top-menu .event-calendar span.text{display: none;}
 .top-menu .social{margin-right: 70px;}

--- a/wp-content/themes/Prozzoro/customer.php
+++ b/wp-content/themes/Prozzoro/customer.php
@@ -16,6 +16,9 @@ Template Name: Замовнику
 			?>							
 			</ul>
 		</div>
+
+		<?php echo do_shortcode('[official-news-in-top]'); ?>
+
 		<?php $field = get_field_object('no-money-blue', $post->ID);?>
 		<h1><a id="perevagy"></a><?php echo _e($field['label']); ?></h1>
 		<div class="system-advantages--steps">

--- a/wp-content/themes/Prozzoro/functions.php
+++ b/wp-content/themes/Prozzoro/functions.php
@@ -392,7 +392,7 @@ function vacancies_in_top(){
     'order' => 'DESC'
   );
   $wp_query = new WP_Query( $args );
-  $cat = get_category_by_slug(vacancies);
+  $cat = get_category_by_slug('vacancies');
   $text_to_site.='<h1 align="center">'.$cat->cat_name.'</h1>';
   if ( $wp_query->have_posts() ) : while ( $wp_query->have_posts() ) : $wp_query->the_post(); 
       $text_to_site.= '<div class="row">
@@ -417,6 +417,36 @@ function vacancies_in_top(){
                       </div>';
       endwhile; endif;
       wp_reset_postdata(); 
+      return $text_to_site;
+  }
+
+add_shortcode('official-news-in-top', 'official_news_in_top');
+function official_news_in_top(){
+  $text_to_site = '';
+  $args = array(
+    'showposts' => 4, 
+    'category_name' =>  'ofitsijni-novyny',
+    'post_status' => 'publish',
+    'orderby' => 'date',
+    'order' => 'DESC'
+  );
+  $wp_query = new WP_Query( $args );
+  $cat = get_category_by_slug('ofitsijni-novyny');
+  $text_to_site.='<h1 align="center"><span id="ua">Останні зміни до законодавства</span><span id="en">Last law revisions</span></h1>';
+  $text_to_site.= '<div class="row">
+                         <div class="gray-bg padding margin-bottom">';
+  if ( $wp_query->have_posts() ) : while ( $wp_query->have_posts() ) : $wp_query->the_post(); 
+      $text_to_site.= '<div class="col-md-3 col-sm-6 col-xs-12"><span class="day">';
+      $text_to_site.= get_the_time('d.m.y');
+      $text_to_site.='</span><p><a href="';
+      $text_to_site.= get_the_permalink(); 
+      $text_to_site.='">';
+      $text_to_site.= get_the_title();
+      $text_to_site.= '</a></p><div class="clearfix"></div>';
+      $text_to_site.= '</div>';
+      endwhile; endif;
+      wp_reset_postdata(); 
+       $text_to_site.='<div class="clearfix"></div></div><div class="blog-all"> <a href="'.get_category_link($cat->term_id).'" ><i class="sprite-arrow-right"></i>  <span id="ua">Перейти до останніх змін до законодавства</span><span id="en">Go to last law revisions</span></a><div class="clearfix"></div></div><hr />';
       return $text_to_site;
   }
 
@@ -644,6 +674,31 @@ function platforms_to_screen(){
 
     $content ='';
     $content .= '<div class="start-steps--platforms-list margin-bottom clearfix"><div class="owl-carousel">';
+    foreach ($platform as $key => $value) {
+      $size = getimagesize($value->logo);
+          if($size[0]>150 || $size[1]>100) { $nw=150; $nh=floor(150/($size[0]/$size[1]));}
+          else {$nw=$size[0]; $nh=$size[1];}        
+      $content .=  '<div class="item" id="'.$value->slug.'"><a href="'.$value->href.'"><img src="'.$value->logo.'" width="'.$nw.'" height="'.$nh.'"  alt="'.$value->name.'" title="'.$value->name.'" /></a><a class="pl-title" href="'.$value->href.'">'.$value->name.'</a><div class="phone"></div></div>';
+    }
+    $content .=  '</div></div>';
+    return $content;
+  }
+}
+add_shortcode('doporodovi-platforms-to-screen', 'doporodovi_platforms_to_screen');
+function doporodovi_platforms_to_screen(){
+    $path='/json/platforms/contractors/';
+
+    if($_SERVER['HTTP_HOST']=='prozorro.lemon.ua'){
+        $api=file_get_contents('http://prozorro.org'.$path);
+    }else{
+        $api=file_get_contents('http://'.$_SERVER['HTTP_HOST'].$path);
+    }
+  $platform = json_decode($api);
+  if (is_array($platform)){
+    shuffle($platform);
+
+    $content ='';
+    $content .= '<div class="start-steps--platforms-list margin-bottom clearfix"><div class="owl-carousel doporodovi">';
     foreach ($platform as $key => $value) {
       $size = getimagesize($value->logo);
           if($size[0]>150 || $size[1]>100) { $nw=150; $nh=floor(150/($size[0]/$size[1]));}

--- a/wp-content/themes/Prozzoro/header.php
+++ b/wp-content/themes/Prozzoro/header.php
@@ -18,8 +18,8 @@
     <link href="<?php bloginfo('wpurl'); ?>/wp-content/themes/Prozzoro/css/owl.carousel.css" rel="stylesheet">
     <link href="<?php bloginfo('wpurl'); ?>/wp-content/themes/Prozzoro/css/owl.theme.css" rel="stylesheet">
     <link rel="stylesheet" href="<?php bloginfo('wpurl'); ?>/wp-content/themes/Prozzoro/style.css">
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>    
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>    
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     <script src="<?php bloginfo('wpurl'); ?>/wp-content/themes/Prozzoro/js/attrchange.js"></script>
     <script src="<?php bloginfo('wpurl'); ?>/wp-content/themes/Prozzoro/js/owl.carousel.js"></script>    
     <script src="<?php bloginfo('wpurl'); ?>/wp-content/themes/Prozzoro/js/script.js"></script>
@@ -85,7 +85,7 @@
                         <span class="icon-bar"></span>
                     </button>
                     <a class="navbar-brand" href="<?php  echo esc_url( home_url( '/' ) ); ?>"><img src="<?php bloginfo('wpurl'); ?>/wp-content/themes/Prozzoro/images/logo-prozorro<?php echo ((qtrans_getLanguage()=='en')?'-en':''); ?>.png" alt="Logo" /></a>
-                    <a class="green-btn registration visible-sm" href="<?php echo get_permalink(253); ?>"><?php _e('[:ua]Зареєструватись[:en]Register'); ?></a>
+                    <a class="green-btn registration visible-sm" href="#"><?php _e('[:ua]Зареєструватись[:en]Register'); ?></a>
                 </div>
 
                 <!-- Collect the nav links, forms, and other content for toggling -->
@@ -113,7 +113,7 @@
 					</div><!-- /.navbar-collapse -->
 				</div>
                 <div class="navbar-header pull-right">
-                    <a class="green-btn registration hidden-md hidden-sm" href="<?php echo get_permalink(253); ?>"><?php _e('[:ua]Зареєструватись[:en]Register'); ?></a>
+                    <a class="green-btn registration hidden-md hidden-sm" href="#"><?php _e('[:ua]Зареєструватись[:en]Register'); ?></a>
                 </div>
             </div><!-- /.container-fluid -->
         </nav>
@@ -125,6 +125,14 @@
 				<li class="blue-bg <?php echo ($cur_post==150 ? 'active':'notitle'); ?>"><a href="<?php echo get_permalink( 150 ) ?>"><i class="sprite-customer"></i> <span><?php echo get_the_title( 150 ) ?></span></a></li>
 			</ul>
 		</div>
+        <section class="startpopup">
+            <div class="startpopup-wrapper">
+                <a href="#" class="close-startpopup">&#215;</a>
+                <h1 id="title" align="center"><?php echo _e('[:ua]Почати роботу[:en]Start working'); ?></h1>
+                <h1 id="btn" align="center"><a class="blue-btn" href="<?php echo get_permalink( get_page_by_path( 'pochaty-robotu-zamovnyku' ) ); ?>"><?php echo _e('[:ua]Як Замовник[:en]I am procurer'); ?></a></h1>
+                <h1 id="btn" align="center"><a class="green-btn" href="<?php echo get_permalink( get_page_by_path( 'pochaty-robotu-postachalnyku' ) ); ?>"><?php echo _e('[:ua]Як Постачальник[:en]I am supplier');?></a></h1>
+            </div>
+        </section>
 
 <div class="site">
 	<div id="content" class="site-content">

--- a/wp-content/themes/Prozzoro/js/script.js
+++ b/wp-content/themes/Prozzoro/js/script.js
@@ -1,5 +1,15 @@
 (function($) {
 $(document).ready( function(){
+
+    $('a.registration').bind('click', function(event){
+        event.preventDefault();
+        $('.startpopup').css('display', 'block');
+    });
+     $('.close-startpopup').bind('click', function(event){
+        event.preventDefault();
+        $('.startpopup').css('display', 'none');
+    });
+
     
     function init_event_calendar() {
         $('.ai1ec-month-view td').has('div.ai1ec-event').has('div.ai1ec-date').each(function() {

--- a/wp-content/themes/Prozzoro/style.css
+++ b/wp-content/themes/Prozzoro/style.css
@@ -49,6 +49,16 @@
 	float: left;
 	padding-right: 10px;
 }
+.alignright {
+	float: right;
+	padding-left: 10px;
+}
+.aligncenter{
+	float: none;
+	display: block;
+	padding: 10px;
+	margin: 0 auto;
+}
 
 .size-full{
 	max-width: 100%;
@@ -1110,6 +1120,77 @@ h3.title{
 	}
 
 }
+/*********************************************** Registration POPUP **********************************************************************************/
+.startpopup{
+	position: fixed;
+    display: none;
+    z-index: 25;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255,255,255,0.61);
+}
+.startpopup-wrapper {
+    position: absolute;
+    z-index: 25;
+    width: 40.25%;
+    min-width: 300px;
+    height: auto;
+    min-height: 350px;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translateY(-50%) translateX(-50%);
+    -moz-transform: translateY(-50%) translateX(-50%);
+    -o-transform: translateY(-50%) translateX(-50%);
+    -ms-transform: translateY(-50%) translateX(-50%);
+    transform: translateY(-50%) translateX(-50%);
+    background-color: #fff;
+    border:2px solid #2ab2ea;
+    padding: 50px;
+    text-align: center;
+    -webkit-box-shadow: 7px 7px 0px 0px rgba(0, 0, 0, 0.11);
+	-moz-box-shadow:    7px 7px 0px 0px rgba(0, 0, 0, 0.11);
+	box-shadow:         7px 7px 0px 0px rgba(0, 0, 0, 0.11);
+}
+.startpopup-wrapper h1{
+	text-align: center;
+}
+.startpopup-wrapper h1#title{
+	margin:0 0 50px;
+}
+.startpopup-wrapper #btn a{
+	padding: 25px;
+	-webkit-box-shadow: 7px 7px 0px 0px rgba(0, 0, 0, 0.11);
+	-moz-box-shadow:    7px 7px 0px 0px rgba(0, 0, 0, 0.11);
+	box-shadow:         7px 7px 0px 0px rgba(0, 0, 0, 0.11);
+}
+.startpopup-wrapper a{
+	width: 90%;
+	display: block;
+	margin: 25px auto;	
+}
+.startpopup-wrapper .close-startpopup {
+    display: block;
+    position: absolute;
+    top:-33px;
+    right: 0;
+    float: right;
+    width: 25px;
+    height: 25px;
+    background-color: #fff;
+    border: 2px solid #2ab2ea;
+    border-radius: 50%;
+    margin: 0;
+    font-size: 20px;
+    line-height: 20px;
+}
+	.startpopup-wrapper a.close-startpopup:hover,
+	.startpopup-wrapper a.close-startpopup:focus{
+		text-decoration: none;
+	}
+
+
 
 /*********************************************** Accordion **********************************************************************************/
 h3.accordion-title{

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -3918,13 +3918,13 @@ function validate_file( $file, $allowed_files = '' ) {
  * @return bool True if SSL, false if not used.
  */
 function is_ssl() {
-	if ( isset($_SERVER['HTTPS']) ) {
-		if ( 'on' == strtolower($_SERVER['HTTPS']) )
-			return true;
-		if ( '1' == $_SERVER['HTTPS'] )
-			return true;
+	if ( isset($_SERVER['HTTP_X_HTTPS']) ) {
+	if ( 'on' == strtolower($_SERVER['HTTP_X_HTTPS']) )
+	return true;
+	if ( '1' == $_SERVER['HTTP_X_HTTPS'] )
+	return true;
 	} elseif ( isset($_SERVER['SERVER_PORT']) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
-		return true;
+	return true;
 	}
 	return false;
 }


### PR DESCRIPTION
2) корректировки ф-ции is_ssl() в wp-includes и header для работы по https-протоколу
3) добавлено попап-окно на кнопку 'Зарегистрироваться' + карусель для Допороговых площадок (входящий файл используется тот же, что и для всех площадок).
P.S. Для главной необходимо добавить скрипт для отображения попап-окна
.bind('click', function(event){
        event.preventDefault();
        .css('display', 'block');
    });
     .bind('click', function(event){
        event.preventDefault();
        .css('display', 'none');
    });
